### PR TITLE
playershipmeshcollider linux build fix

### DIFF
--- a/linux/mono_build.sh
+++ b/linux/mono_build.sh
@@ -48,7 +48,7 @@ mcs \
     -r:../GameMod/0Harmony.dll \
     -target:library \
     -sdk:2 \
-	-resource:../GameMod/Resources/playshipmeshcollider,GameMod.Resources.playershipmeshcollider \
+    -resource:../GameMod/Resources/playershipmeshcollider,GameMod.Resources.playershipmeshcollider \
     -out:GameMod.dll \
     ../GameMod/*.cs \
     ../GameMod/*/*.cs


### PR DESCRIPTION
- use the correct file name `playershipmeshcollider` instead of `playshipmeshcollider`
- fix wrong tab vs. spaces indentation